### PR TITLE
Dev install instructions directory fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ pip install pyclustree
 git clone https://github.com/siebrenf/pyclustree.git
 conda env create -n pyclustree -f pyclustree/requirements.yaml
 conda activate pyclustree
+cd pyclustree/
 pip install --editable . --no-deps --ignore-installed
 ```
 


### PR DESCRIPTION
This error occurs when not navigating into the correct directory before the pip install:

"{dir} does not appear to be a Python project: neither 'setup.py' nor 'pyproject.toml' found."

Navigating inside the cloned repo fixes this.