### PR TITLE
Improving tutorial docs and adding support for leidenalg

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ pip install pyclustree
 git clone https://github.com/siebrenf/pyclustree.git
 conda env create -n pyclustree -f pyclustree/requirements.yaml
 conda activate pyclustree
-cd pyclustree/
-pip install --editable . --no-deps --ignore-installed
+pip install --editable ./pyclustree --no-deps --ignore-installed
 ```
 
 # Tutorial output

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ pip install pyclustree
 git clone https://github.com/siebrenf/pyclustree.git
 conda env create -n pyclustree -f pyclustree/requirements.yaml
 conda activate pyclustree
+cd pyclustree/
 pip install --editable . --no-deps --ignore-installed
 ```
 

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -10,6 +10,7 @@ dependencies:
   - networkx >=2.7
   - numpy >=1.23
   - scanpy >=1.10
+  - leidenalg >=0.10.2
 
   # dev
   - black

--- a/tutorial.py
+++ b/tutorial.py
@@ -15,9 +15,7 @@ adata = sc.datasets.pbmc68k_reduced()
 
 # clustering & plotting (updates adata.obs)
 columns = clustering(adata)
-
-# clustering & plotting (updates adata.obs)
-# alternative if you want to select a different cluster arg, e.g. flavor
+# to select a different cluster args, e.g. flavor, use:
 # columns = clustering(adata, cluster_kwargs={"flavor":"leidenalg"})
 
 tree_columns = clustering_plot(adata, columns)
@@ -28,11 +26,6 @@ clustree_plot(tree_data)
 
 # plot the UMAPs for each resolution
 sc.pl.umap(adata, color=tree_columns, legend_loc="on data", alpha=0.75, ncols=3)
-
-# if needed remove the raw data slot from the adata object
-# this is required since sc.tl.rank_genes_groups(adata, column, use_raw=False)
-# throws a silent error and raw values are still plotter, remove like this:
-# del adata.raw
 
 # plot the top genes per cluster for each resolution
 warnings.simplefilter(action='ignore', category=pd.errors.PerformanceWarning)

--- a/tutorial.py
+++ b/tutorial.py
@@ -15,6 +15,11 @@ adata = sc.datasets.pbmc68k_reduced()
 
 # clustering & plotting (updates adata.obs)
 columns = clustering(adata)
+
+# clustering & plotting (updates adata.obs)
+# alternative if you want to select a different cluster arg, e.g. flavor
+# columns = clustering(adata, cluster_kwargs={"flavor":"leidenalg"})
+
 tree_columns = clustering_plot(adata, columns)
 
 # build tree & plotting (updates adata.obs)
@@ -23,6 +28,11 @@ clustree_plot(tree_data)
 
 # plot the UMAPs for each resolution
 sc.pl.umap(adata, color=tree_columns, legend_loc="on data", alpha=0.75, ncols=3)
+
+# if needed remove the raw data slot from the adata object
+# this is required since sc.tl.rank_genes_groups(adata, column, use_raw=False)
+# throws a silent error and raw values are still plotter, remove like this:
+# del adata.raw
 
 # plot the top genes per cluster for each resolution
 warnings.simplefilter(action='ignore', category=pd.errors.PerformanceWarning)


### PR DESCRIPTION
This error occurs when not navigating into the correct directory before the pip install:
 "{dir} does not appear to be a Python project: neither 'setup.py' nor 'pyproject.toml' found."
Navigating inside the cloned repo fixes this.

I added leidenalg as a dependency if people want to use it instead of igraph. I also adapted the tutorial.py documentation accordingly.

Within the tutorial documentation I added the optional removal of adata.raw as "scanpy.tl.rank_genes_groups" throws silent errors when plotting, taking raw values by default.